### PR TITLE
feat(init.d): add mask to --mark & --set-mark option in iptables rules

### DIFF
--- a/public/root/etc/init.d/v2ray
+++ b/public/root/etc/init.d/v2ray
@@ -28,8 +28,13 @@ TRANSPARENT_PROXY_EXPECTED=0
 TRANSPARENT_PROXY_PORT=
 TRANSPARENT_PROXY_USE_TPROXY=
 TRANSPARENT_PROXY_ADDITION=
+TRANSPARENT_REDIRECT_MARK=255
 
 DNSMASQ_RESTART_EXPECTED=0
+
+IPTABLES_MASK=0xff
+IPTABLES_REDIRECT_MARK=0x1
+IPTABLES_BYPASS_MARK=0xff
 
 . /usr/share/libubox/jshn.sh
 
@@ -398,7 +403,7 @@ add_v2ray_redirect_rules() {
 	iptables-restore --noflush <<-EOF 2>/dev/null
 		*nat
 		:V2RAY -
-		-A V2RAY -p tcp -j RETURN -m mark --mark 0xff
+		-A V2RAY -p tcp -j RETURN -m mark --mark $IPTABLES_BYPASS_MARK/$IPTABLES_MASK
 		-A V2RAY -p tcp -j RETURN -m set --match-set $ipset_src_direct src
 		-A V2RAY -p tcp -j RETURN -m set --match-set $ipset_dst_direct dst
 		-A V2RAY -p tcp $ext_args -j REDIRECT --to-ports $port
@@ -417,27 +422,27 @@ add_v2ray_redirect_rules() {
 	EOF
 
 	if [ -n "$addition" ] ; then
-		ip rule add fwmark 1 lookup 100
+		ip rule add fwmark $IPTABLES_REDIRECT_MASK/$IPTABLES_MARK pref 100 1ookup 100
 		ip route add local 0.0.0.0/0 dev lo table 100 2>/dev/null
 
 		iptables-restore --noflush <<-EOF 2>/dev/null
 			*mangle
 			:V2RAY -
-			-A V2RAY -p udp -j RETURN -m mark --mark 0xff
+			-A V2RAY -p udp -j RETURN -m mark --mark $IPTABLES_BYPASS_MARK/$IPTABLES_MASK
 			$(
 				if [ -n "$lan_ipaddrs" ] ; then
 					local ipaddr
 					for ipaddr in $lan_ipaddrs ; do
-						echo "-A V2RAY -p udp --dport 53 -d $ipaddr -j TPROXY --on-port $port --tproxy-mark 0x1/0x1"
+						echo "-A V2RAY -p udp --dport 53 -d $ipaddr -j TPROXY --on-port $port --tproxy-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 					done
 				fi
 			)
 			-A V2RAY -p udp -j RETURN -m set --match-set $ipset_dst_direct dst
 			$(
 				if [ "$addition" = "dns" ] ; then
-					echo "-A V2RAY -p udp --dport 53 -j TPROXY --on-port $port --tproxy-mark 0x1/0x1"
+					echo "-A V2RAY -p udp --dport 53 -j TPROXY --on-port $port --tproxy-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				else
-					echo "-A V2RAY -p udp -j TPROXY --on-port $port --tproxy-mark 0x1/0x1"
+					echo "-A V2RAY -p udp -j TPROXY --on-port $port --tproxy-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				fi
 
 				if [ -n "$lan_devices" ] ; then
@@ -446,21 +451,21 @@ add_v2ray_redirect_rules() {
 						echo "-A PREROUTING -p udp -i $device -j V2RAY"
 					done
 
-					echo "-A PREROUTING -p udp -j V2RAY -m mark --mark 0x1"
+					echo "-A PREROUTING -p udp -j V2RAY -m mark --mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				else
 					echo "-A PREROUTING -p udp -j V2RAY"
 				fi
 			)
 
 			:V2RAY_MARK -
-			-A V2RAY_MARK -p udp -j RETURN -m mark --mark 0xff
+			-A V2RAY_MARK -p udp -j RETURN -m mark --mark $IPTABLES_BYPASS_MARK/$IPTABLES_MASK
 			-A V2RAY_MARK -p udp -j RETURN -m set --match-set $ipset_src_direct src
 			-A V2RAY_MARK -p udp -j RETURN -m set --match-set $ipset_dst_direct dst
 			$(
 				if [ "$addition" = "dns" ] ; then
-					echo "-A V2RAY_MARK -p udp --dport 53 -j MARK --set-mark 1"
+					echo "-A V2RAY_MARK -p udp --dport 53 -j MARK --set-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				else
-					echo "-A V2RAY_MARK -p udp -j MARK --set-mark 1"
+					echo "-A V2RAY_MARK -p udp -j MARK --set-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				fi
 			)
 			-A OUTPUT -p udp -j V2RAY_MARK
@@ -483,30 +488,30 @@ add_v2ray_tproxy_rules() {
 
 	# https://www.kernel.org/doc/Documentation/networking/tproxy.txt
 
-	ip rule add fwmark 1 lookup 100
+	ip rule add fwmark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK pref 100 lookup 100
 	ip route add local 0.0.0.0/0 dev lo table 100 2>/dev/null
 
 	iptables-restore --noflush <<-EOF 2>/dev/null
 		*mangle
 		:V2RAY -
-		-A V2RAY -j RETURN -m mark --mark 0xff
+		-A V2RAY -j RETURN -m mark --mark $IPTABLES_BYPASS_MARK/$IPTABLES_MASK
 		$(
 			if [ -n "$addition" ] && [ -n "$lan_ipaddrs" ] ; then
 				local ipaddr
 				for ipaddr in $lan_ipaddrs ; do
-					echo "-A V2RAY -p udp --dport 53 -d $ipaddr -j TPROXY --on-port $port --tproxy-mark 0x1/0x1"
+					echo "-A V2RAY -p udp --dport 53 -d $ipaddr -j TPROXY --on-port $port --tproxy-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				done
 			fi
 		)
 		-A V2RAY -j RETURN -m set --match-set $ipset_src_direct src
 		-A V2RAY -j RETURN -m set --match-set $ipset_dst_direct dst
-		-A V2RAY -p tcp $ext_args -j TPROXY --on-port $port --tproxy-mark 0x1/0x1
+		-A V2RAY -p tcp $ext_args -j TPROXY --on-port $port --tproxy-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK
 		$(
 			if [ -n "$addition" ] ; then
 				if [ "$addition" = "dns" ] ; then
-					echo "-A V2RAY -p udp --dport 53 -j TPROXY --on-port $port --tproxy-mark 0x1/0x1"
+					echo "-A V2RAY -p udp --dport 53 -j TPROXY --on-port $port --tproxy-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				else
-					echo "-A V2RAY -p udp -j TPROXY --on-port $port --tproxy-mark 0x1/0x1"
+					echo "-A V2RAY -p udp -j TPROXY --on-port $port --tproxy-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				fi
 			fi
 
@@ -516,23 +521,23 @@ add_v2ray_tproxy_rules() {
 					echo "-A PREROUTING -i $device -j V2RAY"
 				done
 
-				echo "-A PREROUTING -j V2RAY -m mark --mark 0x1"
+				echo "-A PREROUTING -j V2RAY -m mark --mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 			else
 				echo "-A PREROUTING -j V2RAY"
 			fi
 		)
 
 		:V2RAY_MASK -
-		-A V2RAY_MASK -j RETURN -m mark --mark 0xff
+		-A V2RAY_MASK -j RETURN -m mark --mark $IPTABLES_BYPASS_MARK/$IPTABLES_MASK
 		-A V2RAY_MASK -j RETURN -m set --match-set $ipset_src_direct src
 		-A V2RAY_MASK -j RETURN -m set --match-set $ipset_dst_direct dst
-		-A V2RAY_MASK -p tcp $ext_args -j MARK --set-mark 1
+		-A V2RAY_MASK -p tcp $ext_args -j MARK --set-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK
 		$(
 			if [ -n "$addition" ] ; then
 				if [ "$addition" = "dns" ] ; then
-					echo "-A V2RAY_MASK -p udp --dport 53 -j MARK --set-mark 1"
+					echo "-A V2RAY_MASK -p udp --dport 53 -j MARK --set-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				else
-					echo "-A V2RAY_MASK -p udp -j MARK --set-mark 1"
+					echo "-A V2RAY_MASK -p udp -j MARK --set-mark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK"
 				fi
 			fi
 		)
@@ -544,7 +549,7 @@ add_v2ray_tproxy_rules() {
 clear_v2ray_rules() {
 	iptables-save --counters | grep -v "V2RAY" | iptables-restore --counters
 
-	while ip rule del fwmark 1 lookup 100 2>/dev/null ; do true ; done
+	while ip rule del fwmark $IPTABLES_REDIRECT_MARK/$IPTABLES_MASK pref 100 lookup 100 2>/dev/null ; do true ; done
 
 	ip route flush table 100
 	ip route del local 0.0.0.0/0 dev lo table 100 2>/dev/null
@@ -1858,7 +1863,7 @@ add_outbound_setting() {
 	json_add_object "sockopt"
 
 	if [ -n "$TRANSPARENT_PROXY_PORT" ] ; then
-		json_add_int "mark" "255"
+		json_add_int "mark" "$TRANSPARENT_REDIRECT_MARK"
 	else
 		test -n "$ss_sockopt_mark" && \
 			json_add_int "mark" "$ss_sockopt_mark"


### PR DESCRIPTION
When work with mwan3, mwan3 uses 0x3f00 for policy route. So we should only use lower bits for mark
to work with mwan3 and other opwt module.