### PR TITLE
Fix proxy host packages issue under tproxy

### DIFF
--- a/public/root/etc/init.d/v2ray
+++ b/public/root/etc/init.d/v2ray
@@ -524,6 +524,7 @@ add_v2ray_tproxy_rules() {
 
 		:V2RAY_MASK -
 		-A V2RAY_MASK -j RETURN -m mark --mark 0xff
+		-A V2RAY_MASK -j RETURN -o lo
 		-A V2RAY_MASK -j RETURN -m set --match-set $ipset_src_direct src
 		-A V2RAY_MASK -j RETURN -m set --match-set $ipset_dst_direct dst
 		-A V2RAY_MASK -p tcp $ext_args -j MARK --set-mark 1


### PR DESCRIPTION
tproxy转发本机流量到v2ray dokodemo端口，v2ray的响应的DST地址会是本机的地址，所以干脆直接放行所有lo。

https://raw.githubusercontent.com/XGFan/transparent-proxy/master/script/transparent_proxy.sh