### PR TITLE
Add luci-lib-jsonc as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Dependencies:
 - ipset
 - iptables
 - iptables-mod-tproxy
+- luci-lib-jsonc
 - resolveip
 - dnsmasq-full (dnsmasq ipset is required)
 


### PR DESCRIPTION
When I tried to install luci-app-v2ray manually, there was an error message saying I needed luci-app-v2ray as a dependency.